### PR TITLE
[HOLD] Visual scripts for libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Scripts used to centrally manage Travis deployments. These scripts use GitHub Pa
 Repos that use these scripts include:
 - https://github.com/blackbaud/skyux2
 - https://github.com/blackbaud/skyux-builder
+- https://github.com/blackbaud/stache2

--- a/browserstack-cleanup.sh
+++ b/browserstack-cleanup.sh
@@ -1,0 +1,8 @@
+# Kill any remaining BrowserStack tunnels
+echo "Cleaning up BrowerStack instances"
+echo "--- Before ---"
+ps -ef | grep BrowserStackLocal
+pkill -9 -f BrowserStackLocal
+
+echo "--- After ---"
+ps -ef | grep BrowserStackLocal

--- a/library-after-failure.sh
+++ b/library-after-failure.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Fail the build if this step fails
+set -e
+
+# Display any npm errors
+if [ -e ./npm-debug.log ]; then
+  cat ./npm-debug.log
+fi
+
+# Display any browserstack errors
+if [ -e ./browserstack.err ]; then
+  cat ./browserstack.err
+fi
+
+# Check for visual baseline errors
+bash <(curl -s https://blackbaud.github.io/skyux-travis/visual-failures.sh)

--- a/library-after-script.sh
+++ b/library-after-script.sh
@@ -2,7 +2,13 @@
 set -e
 
 # Necessary to stop pull requests from forks from running outside of Savage
-# Upload coverage.
 if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
+  # Publish code coverage results.
   bash <(curl -s https://codecov.io/bash)
+
+  # Kill any BrowserStack processes.
+  bash <(curl -s https://blackbaud.github.io/skyux-travis/browserstack-cleanup.sh)
+
+  # Commits screenshots to the same repo.
+  bash <(curl -s https://blackbaud.github.io/skyux-travis/visual-baseline.sh)
 fi

--- a/library-after-success.sh
+++ b/library-after-success.sh
@@ -4,8 +4,8 @@ set -e
 echo -e "Blackbaud - SKY UX Travis - Library After Success"
 
 # Necessary to stop pull requests from forks from running outside of Savage
-# Publish a tag to NPM
 if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" && -n "$TRAVIS_TAG" ]]; then
+  # Build and publish to NPM.
   skyux build-public-library
   cd dist
   bash <(curl -s https://blackbaud.github.io/skyux-travis/after-success.sh)

--- a/visual-baseline.sh
+++ b/visual-baseline.sh
@@ -15,7 +15,7 @@ if [[ $TRAVIS_BRANCH =~ $SAVAGE_BRANCH ]]; then
   exit 0
 fi
 
-echo -e "Checking for new baseline images...\n"
+echo -e "Checking for new baseline screenshots...\n"
 
 git config --global user.email "sky-build-user@blackbaud.com"
 git config --global user.name "Blackbaud SKY Build User"
@@ -30,9 +30,9 @@ if ! git diff-index --quiet HEAD --; then
   git checkout $TRAVIS_BRANCH --quiet
   git stash pop
   git add screenshots-baseline/
-  git commit -m "Travis build $TRAVIS_BUILD_NUMBER pushed new visual baseline images [ci skip]"
+  git commit -m "Travis build $TRAVIS_BUILD_NUMBER pushed new visual baseline screenshots [ci skip]"
   git push -fq origin $TRAVIS_BRANCH > /dev/null
-  echo -e "Visual baseline images successfully updated.\n"
+  echo -e "Visual baseline screenshots successfully updated.\n"
 else
-  echo -e "No new baseline images found.\n"
+  echo -e "No new baseline screenshots found.\n"
 fi

--- a/visual-baseline.sh
+++ b/visual-baseline.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+
+# ======================================================
+# Abort commit if building a pull request
+# ======================================================
+if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]; then
+  exit 0
+fi
+
+# ======================================================
+# Abort commit if it's a savage branch
+# ======================================================
+if [[ $TRAVIS_BRANCH =~ $SAVAGE_BRANCH ]]; then
+  exit 0
+fi
+
+echo -e "Checking for new baseline images...\n"
+
+git config --global user.email "sky-build-user@blackbaud.com"
+git config --global user.name "Blackbaud SKY Build User"
+git status --short
+git add screenshots-baseline/
+
+# ======================================================
+# Commit the new images to the master branch
+# ======================================================
+if ! git diff-index --quiet HEAD --; then
+  git stash save
+  git checkout $TRAVIS_BRANCH --quiet
+  git stash pop
+  git add screenshots-baseline/
+  git commit -m "Travis build $TRAVIS_BUILD_NUMBER pushed new visual baseline images [ci skip]"
+  git push -fq origin $TRAVIS_BRANCH > /dev/null
+  echo -e "Visual baseline images successfully updated.\n"
+else
+  echo -e "No new baseline images found.\n"
+fi

--- a/visual-failures.sh
+++ b/visual-failures.sh
@@ -1,0 +1,1 @@
+# Need to figure out where libraries should commit diff images to.

--- a/visual-failures.sh
+++ b/visual-failures.sh
@@ -1,1 +1,41 @@
-# Need to figure out where libraries should commit diff images to.
+#!/usr/bin/env bash
+
+# Fail the build if this step fails
+set -e
+
+# This file only runs if there are results from the visualtests
+# It's using the deploy key specified in Travis since Secure Environemnt Variables aren't available to forks.
+
+if [[ "$(ls -A skyux-spa-visual-tests/screenshots-diff)" ]]; then
+
+  echo -e "Starting to update webdriver test results.\n"
+
+  git config --global user.email "sky-build-user@blackbaud.com"
+  git config --global user.name "Blackbaud Sky Build User"
+  git clone --quiet https://${GH_TOKEN}@github.com/blackbaud/skyux-visualtest-results.git skyux-visualtest-results-webdriver > /dev/null
+
+  cd skyux-visualtest-results-webdriver
+
+  branch="skyux-lib-$TRAVIS_BUILD_ID-webdriver"
+
+  if [[ $TRAVIS_BRANCH =~ $SAVAGE_BRANCH ]]; then
+    branch="$branch-savage"
+  fi
+
+  git checkout -b $branch
+  cp -rf ../screenshots-created/ created-screenshots/
+  mkdir -p failures
+  cp -rf ../screenshots-diff/ failures/
+  mkdir -p all
+  cp -rf ../screenshots-baseline/ all/
+
+  git add -A
+  if [ -z "$(git status --porcelain)" ]; then
+    echo -e "No new screenshots found."
+  else
+    git commit -m "Travis build $TRAVIS_BUILD_NUMBER webdriver screenshot results pushed to skyux-visualtest-results"
+    git push -fq origin $branch > /dev/null
+    echo "New screenshots successfully committed.\n"
+    echo -e "Test results may be viewed at https://github.com/blackbaud/skyux-visualtest-results/tree/$branch"
+  fi
+fi


### PR DESCRIPTION
These scripts will commit baseline screenshots back into the same repo, or diff images into another repo.

To be used with Builder's new `skyux visual --platform travis` command.
https://github.com/blackbaud/skyux-builder/pull/373