### PR TITLE
Fix private npm installs

### DIFF
--- a/v3/library-install.sh
+++ b/v3/library-install.sh
@@ -4,8 +4,7 @@ set -e
 # Necessary to stop pull requests from forks from running.
 if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
   npm install
-  npm install --no-save blackbaud/skyux-builder-config
-  npm install --no-save blackbaud/skyux-sdk-builder-config
+  npm install --no-save blackbaud/skyux-builder-config blackbaud/skyux-sdk-builder-config
 else
   echo -e "Ignoring script. Pull requests from forks are run elsewhere."
 fi


### PR DESCRIPTION
Installs work for `@skyux-sdk/builder` projects, but not for `@blackbaud/skyux-builder` projects.

Running consecutive `npm i --no-save` will erase the previous install.
See: https://github.com/npm/npm/issues/17927

Placing all private packages within a single command, however, works as expected.